### PR TITLE
Fix build error

### DIFF
--- a/mcaApp/CanberraSrc/nmc_sys_defs.h
+++ b/mcaApp/CanberraSrc/nmc_sys_defs.h
@@ -29,6 +29,7 @@
 #include <epicsEvent.h>
 #include <epicsThread.h>
 #include <epicsString.h>
+#include <osiSock.h>
 
 #ifdef USE_SOCKETS
   #include <sys/socket.h>


### PR DESCRIPTION
The error is due to an update to pcap which now does a

    #define SOCKET int

which conflicts with epics base

    typedef int SOCKET

leading to

    typedef int int

Adding an earlier EPICS include of socket works around the issue, but
maybe epics base should do a "ifdef/ifndef SOCKET" test?

See ISISComputingGroup/IBEX#3616
